### PR TITLE
README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,23 @@ import VueAutowire from 'vue-autowire'
 import defaultConventions from 'vue-autowire/src/conventions';
 Vue.use(VueAutowire, defaultConventions)
 
-// Auto wire only certain assets, but with their default conventions
+Vue.config.productionTip = false
+
+new Vue({
+  render: h => h(App),
+}).$mount('#app')
+```
+
+Auto wire only certain assets, but with their default conventions
+
+``` js
 import componentsConventions from 'vue-autowire/src/conventions/components';
 Vue.use(VueAutowire, componentsConventions)
+```
 
-// Mix and match defaults and your custom conventions
+Mix and match defaults and your custom conventions
+
+``` js
 import componentsConventions from 'vue-autowire/src/conventions/components';
 Vue.use(VueAutowire, Object.assign(componentsConventions, {
   views: {
@@ -36,12 +48,6 @@ Vue.use(VueAutowire, Object.assign(componentsConventions, {
     requireAsyncContext: require.context('./views', true, /\.async\.vue$/, 'lazy'),
   }
 }))
-
-Vue.config.productionTip = false
-
-new Vue({
-  render: h => h(App),
-}).$mount('#app')
 ```
 
 Read through the docs at https://kaizendorks.github.io/vue-autowire/ for more information about the default conventions and how to create your own.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Vue.use(VueAutowire, Object.assign(componentsConventions, {
     // Provide your own views convention. For example:
     // register all .vue files (excluding .local.vue and .async.vue) inside the /views folder as regular components
     requireContext: require.context('./views', true, /\/(?:[^.]+|(?!\.local\.vue$)|(?!\.async\.vue$))\.vue$/),
-    // register all .async.vue files inside the /views folder as dynamic componentst
+    // register all .async.vue files inside the /views folder as dynamic components
     requireAsyncContext: require.context('./views', true, /\.async\.vue$/, 'lazy'),
   }
 }))


### PR DESCRIPTION
Two updates to the README:
- Correct typo in a code comment
- Split the code example into three snippets to better illustrate that the `Vue.use` can be called only once when configuring the plugin. As a new Vue user, I was wondering why consecutive calls to `Vue.use`, as shown in the current example, weren't stacking.