### PR TITLE
For the list of results for inspection: 

### DIFF
--- a/src/autowire.js
+++ b/src/autowire.js
@@ -162,25 +162,25 @@ function autowire (Vue, conventions) {
     filters: assetResults.filters,
     directives: assetResults.directives,
     registerComponents: function (requireContext) {
-      this.components = assetResults.components.concat(registerComponents(Vue, requireContext));
+      this.components = this.components.concat(registerComponents(Vue, requireContext));
     },
     registerAsyncComponents: function (requireContext) {
-      this.asyncComponents = assetResults.asyncComponents.concat(registerAsyncComponents(Vue, requireContext));
+      this.asyncComponents = this.asyncComponents.concat(registerAsyncComponents(Vue, requireContext));
     },
     registerViews: function (requireContext) {
-      this.views = assetResults.views.concat(registerComponents(Vue, requireContext));
+      this.views = this.views.concat(registerComponents(Vue, requireContext));
     },
     registerAsyncViews: function (requireContext) {
-      this.asyncViews = assetResults.asyncViews.concat(registerAsyncComponents(Vue, requireContext));
+      this.asyncViews = this.asyncViews.concat(registerAsyncComponents(Vue, requireContext));
     },
     registerRoutes: function (requireContext) {
-      this.routes = assetResults.routes.concat(registerRoutes(Vue, requireContext));
+      this.routes = this.routes.concat(registerRoutes(Vue, requireContext));
     },
     registerFilters: function (requireContext) {
-      this.filters = assetResults.filters.concat(registerFilters(Vue, requireContext));
+      this.filters = this.filters.concat(registerFilters(Vue, requireContext));
     },
     registerDirectives: function (requireContext) {
-      this.directives = assetResults.directives.concat(registerDirectives(Vue, requireContext));
+      this.directives = this.directives.concat(registerDirectives(Vue, requireContext));
     },
   };
 

--- a/test/unit/autowire.spec.js
+++ b/test/unit/autowire.spec.js
@@ -64,6 +64,8 @@ describe('the VueAutowire module', () => {
       let mockRouteFiles;
       let mockRequireContextNew;
       let mockRouteFilesNew;
+      let mockRequireContextNew2;
+      let mockRouteFilesNew2;
 
       beforeEach(() => {
         mockRouteFiles = [
@@ -117,18 +119,31 @@ describe('the VueAutowire module', () => {
         when(mockRequireContextNew).calledWith(mockRouteFilesNew[0]).mockReturnValue({ a: 'new set of routes' });
         when(mockRequireContextNew).calledWith(mockRouteFilesNew[1]).mockReturnValue({ another: 'new set of routes' });
 
+        mockRouteFilesNew2 = [
+          'extra/path/my-router.js',
+          'extra/other/path/another-router.js'
+        ];
+        mockRequireContextNew2 = jest.fn();
+        mockRequireContextNew2.keys = jest.fn().mockReturnValue(mockRouteFilesNew2);
+
+        when(mockRequireContextNew2).calledWith(mockRouteFilesNew2[0]).mockReturnValue({ an: 'extra set of routes' });
+        when(mockRequireContextNew2).calledWith(mockRouteFilesNew2[1]).mockReturnValue({ another: 'extra set of routes' });
+
         VueAutowire(mockVue, Object.assign(mockConventions, {
           routes: { requireContext: mockRequireContext }
         }));
 
         mockVue.autowire.registerRoutes(mockRequireContextNew);
+        mockVue.autowire.registerRoutes(mockRequireContextNew2);
 
         expect(mockVue.autowire).toMatchObject({
           routes: [
             { a: 'set of routes' },
             { another: 'set of routes' },
             { a: 'new set of routes' },
-            { another: 'new set of routes' }
+            { another: 'new set of routes' },
+            { an: 'extra set of routes' },
+            { another: 'extra set of routes' }
           ],
         });
       });


### PR DESCRIPTION
the current functionality always uses initial list and add the new list. It should use the latest list (including any previous updates) and add the new list.

Relates to #22 